### PR TITLE
Add script for automating GitHub issue creation

### DIFF
--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -443,6 +443,16 @@ Integrate robust plagiarism checkers that can identify uncredited content, inclu
 
 ## 📋 Issue Creation Checklist
 
+### Automated Issue Creation
+You can automatically create all issues using the Python script at `scripts/create_github_issues.py`. Set the environment variables `GITHUB_TOKEN` (a personal access token) and `GITHUB_REPO` (e.g. `username/repo`) then run:
+
+```bash
+python scripts/create_github_issues.py
+```
+
+The script parses this document and creates matching GitHub issues with labels and descriptions.
+
+
 For each issue, ensure you:
 - [ ] Use the exact title from this document
 - [ ] Add all specified labels

--- a/scripts/create_github_issues.py
+++ b/scripts/create_github_issues.py
@@ -1,0 +1,71 @@
+import os
+import re
+import requests
+
+TOKEN = os.getenv('GITHUB_TOKEN')
+REPO = os.getenv('GITHUB_REPO')  # e.g. "owner/repo"
+
+if not TOKEN or not REPO:
+    raise SystemExit('GITHUB_TOKEN and GITHUB_REPO environment variables are required')
+
+API_URL = f'https://api.github.com/repos/{REPO}/issues'
+HEADERS = {
+    'Authorization': f'token {TOKEN}',
+    'Accept': 'application/vnd.github+json'
+}
+
+issues = []
+current = None
+body_lines = []
+
+with open('docs/GITHUB_ISSUES.md', 'r', encoding='utf-8') as f:
+    for line in f:
+        issue_match = re.match(r'### Issue #\d+: (.*)', line)
+        if issue_match:
+            if current:
+                current['body'] = ''.join(body_lines).strip()
+                issues.append(current)
+                body_lines = []
+            current = {
+                'title': issue_match.group(1).strip(),
+                'labels': [],
+                'assignee': None
+            }
+            continue
+        if current:
+            label_match = re.match(r'\*\*Labels\*\*: (.*)', line)
+            if label_match:
+                current['labels'] = [l.strip('`') for l in label_match.group(1).split(',')]
+                continue
+            assignee_match = re.match(r'\*\*Assignee\*\*: (.*)', line)
+            if assignee_match:
+                assignee = assignee_match.group(1).strip()
+                if assignee.lower() != 'none':
+                    current['assignee'] = assignee
+                continue
+            end_match = re.match(r'^---', line)
+            if end_match:
+                if current:
+                    current['body'] = ''.join(body_lines).strip()
+                    issues.append(current)
+                    current = None
+                    body_lines = []
+                continue
+            body_lines.append(line)
+    if current:
+        current['body'] = ''.join(body_lines).strip()
+        issues.append(current)
+
+for issue in issues:
+    data = {
+        'title': issue['title'],
+        'body': issue['body'],
+        'labels': issue['labels'],
+    }
+    if issue['assignee']:
+        data['assignees'] = [issue['assignee']]
+    resp = requests.post(API_URL, json=data, headers=HEADERS)
+    if resp.status_code == 201:
+        print(f"Created issue: {issue['title']}")
+    else:
+        print(f"Failed to create issue {issue['title']}: {resp.status_code} {resp.text}")


### PR DESCRIPTION
## Summary
- add `create_github_issues.py` script to parse `docs/GITHUB_ISSUES.md` and create issues through GitHub API
- document how to run the script in `GITHUB_ISSUES.md`

## Testing
- `npm test` *(fails: can't cd to src/frontend)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685aefbfc8488329b436aaf9c47aa936